### PR TITLE
Supporting Laravel 7.0 and fixing missing dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     ],
     "require": {
         "php": ">=7.4.0",
-        "laravel/framework": "^6.0"
+        "laravel/framework": "^6.0 || ^7.0"
+        "laravel-enso/helpers": "^1.15"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require": {
         "php": ">=7.4.0",
-        "laravel/framework": "^6.0 || ^7.0"
+        "laravel/framework": "^6.0 || ^7.0",
         "laravel-enso/helpers": "^1.15"
     },
     "autoload": {


### PR DESCRIPTION
I haven't tested yet whether 7.0 won't fail, but I don't think, from the changelog, there are any breaking changes.

Also added the larael-enso/helpers dependency as that was missing and had to be manually installed.