### PR TITLE
support laravel 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,7 @@
     ],
     "require": {
         "php": ">=7.4.0",
-        "laravel/framework": "^7.0",
-        "laravel-enso/helpers": "^2.0"
+        "laravel/framework": "^7.0|^8.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I updated constraint to support laravel 8

and I didn't find any classes from `laravel-enso/helpers`, so I removed it too.

if I missed something, let me know I will fix and push again
