### PR TITLE
#21 add laravel 9 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require": {
         "php": ">=8.0",
-        "laravel/framework": "^9.0"
+        "laravel/framework": "^8.0|^9.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require": {
         "php": ">=8.0",
-        "laravel/framework": "^8.0"
+        "laravel/framework": "^9.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Allowing for 9 allowed us to upgrade, and our automated tests continued to pass, including those which cover the optimistic locking.

Thanks,
Neil